### PR TITLE
Fixing provider references from current to source for clarity

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,3 +1,3 @@
 locals {
-  share_cross_account = data.aws_caller_identity.current.account_id != data.aws_caller_identity.destination.account_id
+  share_cross_account = data.aws_caller_identity.source.account_id != data.aws_caller_identity.destination.account_id
 }

--- a/main.tf
+++ b/main.tf
@@ -123,9 +123,9 @@ resource "aws_glue_catalog_table" "destination_account_table_resource_link" {
   database_name = each.value.destination_database.database_name                   # what database to place the resource link into
   target_table {
     name          = each.key # the shared database
-    catalog_id    = data.aws_caller_identity.current.account_id
+    catalog_id    = data.aws_caller_identity.source.account_id
     database_name = each.value.source_database # shared database
-    region        = data.aws_region.current.name
+    region        = data.aws_region.source.name
   }
 
   depends_on = [aws_lakeformation_permissions.table_share_all, aws_lakeformation_permissions.table_share_selected]


### PR DESCRIPTION
Last PR didn't complete the conversion from using `current` and `target` as providers to using `source` and `destination`.

Code has now been updated to fix this bug.

https://github.com/ministryofjustice/analytical-platform/issues/5289